### PR TITLE
C++ 対応

### DIFF
--- a/src/komega.h
+++ b/src/komega.h
@@ -21,33 +21,37 @@ For more details, See ‘COPYING.LESSER’ in the root directory of this library
 #include <complex.h>
 #pragma once
 
-void komega_bicg_init(int *ndim, int *nl, int *nz, double complex *x,
-                      double complex *z, int *itermax, double *threshold, int *comm);
-void komega_cocg_init(int *ndim, int *nl, int *nz, double complex *x,
-                      double complex *z, int *itermax, double *threshold, int *comm);
-void komega_cg_c_init(int *ndim, int *nl, int *nz, double complex *x,
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void komega_bicg_init(int *ndim, int *nl, int *nz, double _Complex *x,
+                      double _Complex *z, int *itermax, double *threshold, int *comm);
+void komega_cocg_init(int *ndim, int *nl, int *nz, double _Complex *x,
+                      double _Complex *z, int *itermax, double *threshold, int *comm);
+void komega_cg_c_init(int *ndim, int *nl, int *nz, double _Complex *x,
                       double *z, int *itermax, double *threshold, int *comm);
 void komega_cg_r_init(int *ndim, int *nl, int *nz, double *x,
                       double *z, int *itermax, double *threshold, int *comm);
 
-void komega_bicg_restart(int *ndim, int *nl, int *nz, double complex *x,
-                         double complex *z, int *itermax, double *threshold,
-                         int *status, int *iter_old, double complex *v2,
-                         double complex *v12, double complex *v4, double complex *v14,
-                         double complex *alpha_save, double complex *beta_save,
-                         double complex *z_seed, double complex *r_l_save, int *comm);
-void komega_cocg_restart(int *ndim, int *nl, int *nz, double complex *x,
-                         double complex *z, int *itermax, double *threshold,
-                         int *status, int *iter_old, double complex *v2,
-                         double complex *v12, 
-                         double complex *alpha_save, double complex *beta_save,
-                         double complex *z_seed, double complex *r_l_save, int *comm);
-void komega_cg_c_restart(int *ndim, int *nl, int *nz, double complex *x,
+void komega_bicg_restart(int *ndim, int *nl, int *nz, double _Complex *x,
+                         double _Complex *z, int *itermax, double *threshold,
+                         int *status, int *iter_old, double _Complex *v2,
+                         double _Complex *v12, double _Complex *v4, double _Complex *v14,
+                         double _Complex *alpha_save, double _Complex *beta_save,
+                         double _Complex *z_seed, double _Complex *r_l_save, int *comm);
+void komega_cocg_restart(int *ndim, int *nl, int *nz, double _Complex *x,
+                         double _Complex *z, int *itermax, double *threshold,
+                         int *status, int *iter_old, double _Complex *v2,
+                         double _Complex *v12, 
+                         double _Complex *alpha_save, double _Complex *beta_save,
+                         double _Complex *z_seed, double _Complex *r_l_save, int *comm);
+void komega_cg_c_restart(int *ndim, int *nl, int *nz, double _Complex *x,
                          double *z, int *itermax, double *threshold,
-                         int *status, int *iter_old, double complex *v2,
-                         double complex *v12, 
+                         int *status, int *iter_old, double _Complex *v2,
+                         double _Complex *v12, 
                          double *alpha_save, double *beta_save,
-                         double *z_seed, double complex *r_l_save, int *comm);
+                         double *z_seed, double _Complex *r_l_save, int *comm);
 void komega_cg_r_restart(int *ndim, int *nl, int *nz, double *x,
                          double *z, int *itermax, double *threshold,
                          int *status, int *iter_old, double *v2,
@@ -55,29 +59,29 @@ void komega_cg_r_restart(int *ndim, int *nl, int *nz, double *x,
                          double *alpha_save, double *beta_save,
                          double *z_seed, double *r_l_save, int *comm);
 
-void komega_bicg_update(double complex *v12, double complex *v2,
-                        double complex *v14, double complex *v4,
-                        double complex *x, double complex *r_l, int *status);
-void komega_cocg_update(double complex *v12, double complex *v2,
-                        double complex *x, double complex *r_l, int *status);
-void komega_cg_c_update(double complex *v12, double complex *v2,
-                        double complex *x, double complex *r_l, int *status);
+void komega_bicg_update(double _Complex *v12, double _Complex *v2,
+                        double _Complex *v14, double _Complex *v4,
+                        double _Complex *x, double _Complex *r_l, int *status);
+void komega_cocg_update(double _Complex *v12, double _Complex *v2,
+                        double _Complex *x, double _Complex *r_l, int *status);
+void komega_cg_c_update(double _Complex *v12, double _Complex *v2,
+                        double _Complex *x, double _Complex *r_l, int *status);
 void komega_cg_r_update(double *v12, double *v2,
                         double *x, double *r_l, int *status);
 
 
-void komega_bicg_getcoef(double complex *alpha_save, double complex *beta_save,
-                         double complex *z_seed, double complex *r_l_save);
-void komega_cocg_getcoef(double complex *alpha_save, double complex *beta_save,
-                         double complex *z_seed, double complex *r_l_save);
+void komega_bicg_getcoef(double _Complex *alpha_save, double _Complex *beta_save,
+                         double _Complex *z_seed, double _Complex *r_l_save);
+void komega_cocg_getcoef(double _Complex *alpha_save, double _Complex *beta_save,
+                         double _Complex *z_seed, double _Complex *r_l_save);
 void komega_cg_c_getcoef(double *alpha_save, double *beta_save,
-                         double *z_seed, double complex *r_l_save);
+                         double *z_seed, double _Complex *r_l_save);
 void komega_cg_r_getcoef(double *alpha_save, double *beta_save,
                          double *z_seed, double *r_l_save);
 
-void komega_bicg_getvec(double complex *r_old, double complex *r_tilde_old);
-void komega_cocg_getvec(double complex *r_old);
-void komega_cg_c_getvec(double complex *r_old);
+void komega_bicg_getvec(double _Complex *r_old, double _Complex *r_tilde_old);
+void komega_cocg_getvec(double _Complex *r_old);
+void komega_cg_c_getvec(double _Complex *r_old);
 void komega_cg_r_getvec(double *r_old);
 
 void komega_bicg_getresidual(double *res);
@@ -89,3 +93,8 @@ void komega_bicg_finalize();
 void komega_cocg_finalize();
 void komega_cg_r_finalize();
 void komega_cg_c_finalize();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+


### PR DESCRIPTION
C++ で使えるようにしました。

`std::vector` とか `std::complex` とかを受け取れるようにするラッパがあったほうが便利な気もしますが、それはやっていません。