### PR TITLE
Avoid out-of-bounds write to v12(1) when ndim == 0 (empty MPI partition)

### DIFF
--- a/src/komega_bicg.F90
+++ b/src/komega_bicg.F90
@@ -323,14 +323,13 @@ SUBROUTINE komega_BICG_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -354,6 +353,8 @@ SUBROUTINE komega_BICG_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_BICG_restart
 !>
@@ -431,14 +432,13 @@ SUBROUTINE komega_BICG_update(v12, v2, v14, v4, x, r_l, status) BIND(C)
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -472,6 +472,8 @@ SUBROUTINE komega_BICG_update(v12, v2, v14, v4, x, r_l, status) BIND(C)
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_BICG_update
 !>

--- a/src/komega_cg_c.F90
+++ b/src/komega_cg_c.F90
@@ -260,14 +260,13 @@ SUBROUTINE komega_CG_C_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -291,6 +290,8 @@ SUBROUTINE komega_CG_C_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_CG_C_restart
 !
@@ -360,14 +361,13 @@ SUBROUTINE komega_CG_C_update(v12, v2, x, r_l, status) BIND(C)
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -396,6 +396,8 @@ SUBROUTINE komega_CG_C_update(v12, v2, x, r_l, status) BIND(C)
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_CG_C_update
 !

--- a/src/komega_cg_r.F90
+++ b/src/komega_cg_r.F90
@@ -260,14 +260,13 @@ SUBROUTINE komega_CG_R_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
   !
   ! Convergence check
   !
-  v12(1) = SQRT(ddotMPI(ndim, v2, v2))
-  resnorm = v12(1)
+  resnorm = SQRT(ddotMPI(ndim, v2, v2))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(v12(1) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -291,6 +290,8 @@ SUBROUTINE komega_CG_R_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_CG_R_restart
 !
@@ -360,14 +361,13 @@ SUBROUTINE komega_CG_R_update(v12, v2, x, r_l, status) BIND(C)
   !
   ! Convergence check
   !
-  v12(1) = SQRT(ddotMPI(ndim, v2, v2))
-  resnorm = v12(1)
+  resnorm = SQRT(ddotMPI(ndim, v2, v2))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(v12(1) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -396,6 +396,8 @@ SUBROUTINE komega_CG_R_update(v12, v2, x, r_l, status) BIND(C)
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_CG_R_update
 !

--- a/src/komega_cocg.F90
+++ b/src/komega_cocg.F90
@@ -260,14 +260,13 @@ SUBROUTINE komega_COCG_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -291,6 +290,8 @@ SUBROUTINE komega_COCG_restart(ndim0, nl0, nz0, x, z0, itermax0, threshold0, sta
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_COCG_restart
 !
@@ -362,14 +363,13 @@ SUBROUTINE komega_COCG_update(v12, v2, x, r_l, status) BIND(C)
   !
   ! Convergence check
   !
-  v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
-  resnorm = DBLE(v12(1))
+  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
   !
   DO iz = 1, nz
-     IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
-  IF(DBLE(v12(1)) < threshold) THEN
+  IF(resnorm < threshold) THEN
      !
      ! Converged
      !
@@ -403,6 +403,8 @@ SUBROUTINE komega_COCG_update(v12, v2, x, r_l, status) BIND(C)
      status(1) = iter
      status(2) = 0
   END IF
+  !
+  IF(ndim > 0) v12(1) = resnorm
   !
 END SUBROUTINE komega_COCG_update
 !


### PR DESCRIPTION
## Problem

The convergence check in every `*_restart` / `*_update` routine of all four
solvers uses `v12(1)` as scratch storage for the residual 2-norm:

```fortran
v12(1) = CMPLX(SQRT(DBLE(zdotcMPI(ndim,v2,v2))), 0d0, KIND(0d0))
resnorm = DBLE(v12(1))
DO iz = 1, nz
   IF(ABS(v12(1)/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
END DO
IF(DBLE(v12(1)) < threshold) THEN
   ...
```

`v12` is declared `v12(ndim)`. On an MPI rank that owns **no rows**
(`ndim == 0` — more processes than matrix rows, or an unbalanced row
distribution) `v12` is a zero-length array, so writing `v12(1)` is an
out-of-bounds access. With array-bounds checking this aborts; without it,
it silently writes into adjacent memory.

## Fix

Compute the (globally reduced, identical on every rank) residual norm into the
existing local `resnorm`, run the convergence test on `resnorm`, and write it
back to `v12(1)` **only when `ndim > 0`**:

```fortran
resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
DO iz = 1, nz
   IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
END DO
IF(resnorm < threshold) THEN
   ...
IF(ndim > 0) v12(1) = resnorm
```

`v12(1)` is the residual norm the caller reads back for monitoring, so the
value seen by callers with `ndim > 0` is unchanged — only the illegal
`ndim == 0` write is removed.

Applied to all four solvers (BiCG, COCG, CG_R, CG_C), both the `restart` and
`update` entry points (8 sites).

## Notes

- HPhi's vendored copy of `komega_bicg` already carries this guard
  (`IF(ndim > 0) v12(1) = resnorm`); this PR ports it upstream and extends it
  to the sibling solvers.
- Behaviour for `ndim > 0` is bit-for-bit unchanged: serial `gfortran` and
  `mpif90` builds compile cleanly, and `test/solve_rr` output is identical with
  and without the patch. (The `solve_cc/cr/rc` test drivers segfault on macOS
  arm64 **both with and without** this patch — a pre-existing, unrelated test
  issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)