### PR TITLE
Always deallocate lz_conv in komega_CG_R_finalize

### DIFF
--- a/src/komega_cg_r.F90
+++ b/src/komega_cg_r.F90
@@ -465,10 +465,10 @@ SUBROUTINE komega_CG_R_finalize() BIND(C)
   !
   IMPLICIT NONE
   !
-  DEALLOCATE(z, v3, pi, pi_old, p)
+  DEALLOCATE(z, v3, pi, pi_old, p, lz_conv)
   !
   IF(itermax > 0) THEN
-     DEALLOCATE(alpha_save, beta_save, r_l_save, pi_save, lz_conv)
+     DEALLOCATE(alpha_save, beta_save, r_l_save, pi_save)
   END IF
   !
 END SUBROUTINE komega_CG_R_finalize


### PR DESCRIPTION
## Problem

In `src/komega_cg_r.F90`, `lz_conv` is `ALLOCATE`d unconditionally in
`komega_CG_R_init` (alongside `z, v3, pi, pi_old, p`), but
`komega_CG_R_finalize` only `DEALLOCATE`s it inside the `IF(itermax > 0)`
block:

```fortran
DEALLOCATE(z, v3, pi, pi_old, p)
IF(itermax > 0) THEN
   DEALLOCATE(alpha_save, beta_save, r_l_save, pi_save, lz_conv)  ! lz_conv wrongly here
END IF
```

When `komega_CG_R` is driven with `itermax == 0`, `lz_conv` is never
deallocated. It leaks, and a subsequent `komega_CG_R_init` aborts (with
bounds checking) with:

```
Attempting to allocate already allocated variable 'lz_conv'
```

The other three solvers (`bicg`, `cocg`, `cg_c`) already deallocate
`lz_conv` unconditionally next to `z, v3, pi, pi_old, p`; `cg_r` was the
only one with the allocation/deallocation asymmetry.

## Fix

Move `lz_conv` out of the `itermax > 0` block into the unconditional
`DEALLOCATE`, matching the allocation in `komega_CG_R_init` and the other
three solvers. Behavior is unchanged for `itermax > 0` runs.

## Verification

- Serial (`gfortran`) and MPI (`mpif90`) builds are clean.
- All four test drivers (`solve_rr/rc/cr/cc`) converge in 5 iterations.
- A minimal `init/finalize` x2 program with `itermax == 0` aborts on the
  unpatched code at the second `init` and passes with this patch
  (verified under `-fcheck=all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)