### PR TITLE
Auto-detect BLAS complex-return ABI for zdotc/zdotu

### DIFF
--- a/configure
+++ b/configure
@@ -1438,7 +1438,9 @@ Optional Features:
                           optimize for fast installation [default=yes]
   --disable-libtool-lock  avoid locking (might break parallel builds)
   --enable-threadsafe     Thread-safe mode (experimental).
-  --disable-zdot          Do not use ZDOTC and ZDOTU in BLAS.
+  --enable-zdot, --disable-zdot
+                          Use (yes) or do not use (no) ZDOTC and ZDOTU from
+                          BLAS. Default: autodetect the BLAS ABI.
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -21524,17 +21526,75 @@ if test x"$enable_threadsafe" != xno; then
   FCFLAGS="$FCFLAGS -D__KOMEGA_THREAD"
 fi
 #
-# zdotc and adotu
+# zdotc and zdotu
 #
+# The reference (f2c/g77) BLAS returns a COMPLEX result through a hidden first
+# pointer argument, whereas komega_math.F90 declares zdotc/zdotu as ordinary
+# register-return COMPLEX(8) FUNCTIONs. When --enable-zdot or --disable-zdot is
+# given explicitly we honor it; otherwise we autodetect the BLAS complex-return
+# ABI and define -D__NO_ZDOT (use Fortran intrinsics) when the BLAS zdotc does
+# not use the register-return convention. zdotu shares the same complex-return
+# convention as zdotc, so probing zdotc alone is sufficient.
 # Check whether --enable-zdot was given.
 if test "${enable_zdot+set}" = set; then :
-  enableval=$enable_zdot;
+  enableval=$enable_zdot; zdot_explicit=yes
 else
-  enable_zdot=yes
+  zdot_explicit=no; enable_zdot=yes
 fi
 
-if test x"$enable_zdot" != xyes; then
-  FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+if test x"$zdot_explicit" = xyes; then
+  if test x"$enable_zdot" != xyes; then
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether BLAS zdotc uses the register-return ABI" >&5
+$as_echo_n "checking whether BLAS zdotc uses the register-return ABI... " >&6; }
+  cat > conftestzdot.f90 <<'_KOMEGAEOF'
+      program conftest_zdotc
+      implicit none
+      complex(8) :: zx(2), zy(2), res
+      complex(8) :: zdotc
+      external zdotc
+      zx(1) = (1d0, 0d0)
+      zx(2) = (0d0, 1d0)
+      zy(1) = (1d0, 0d0)
+      zy(2) = (0d0, 1d0)
+      res = zdotc(2, zx, 1, zy, 1)
+      if (abs(dble(res) - 2d0) < 1d-8 .and. abs(aimag(res)) < 1d-8) then
+        stop 0
+      else
+        stop 1
+      end if
+      end program conftest_zdotc
+_KOMEGAEOF
+  zdot_abi_ok=no
+  if { echo "$as_me:${as_lineno-$LINENO}: $FC $FCFLAGS $LDFLAGS -o conftestzdot$ac_exeext conftestzdot.f90 $LAPACK_LIBS $BLAS_LIBS $LIBS" >&5
+       $FC $FCFLAGS $LDFLAGS -o conftestzdot$ac_exeext conftestzdot.f90 $LAPACK_LIBS $BLAS_LIBS $LIBS >&5 2>&5; }; then
+    if test "$cross_compiling" = yes; then
+      zdot_abi_ok=cross
+    elif sh -c "./conftestzdot$ac_exeext; exit \$?" >&5 2>&5; then
+      zdot_abi_ok=yes
+    else
+      zdot_abi_ok=no
+    fi
+  else
+    zdot_abi_ok=no
+  fi
+  rm -f conftestzdot.f90 conftestzdot$ac_exeext conftestzdot.o conftest_zdotc.mod
+  if test x"$zdot_abi_ok" = xyes; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+  elif test x"$zdot_abi_ok" = xcross; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: assuming no (cross-compiling)" >&5
+$as_echo "assuming no (cross-compiling)" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot run a test program while cross-compiling; assuming the BLAS zdotc/zdotu are unusable and defining -D__NO_ZDOT. Pass --enable-zdot to force use of the BLAS routines." >&5
+$as_echo "$as_me: WARNING: cannot run a test program while cross-compiling; assuming the BLAS zdotc/zdotu are unusable and defining -D__NO_ZDOT. Pass --enable-zdot to force use of the BLAS routines." >&2;}
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  fi
 fi
 echo ""
 echo "  Output files"

--- a/configure.ac
+++ b/configure.ac
@@ -72,13 +72,67 @@ if test x"$enable_threadsafe" != xno; then
   FCFLAGS="$FCFLAGS -D__KOMEGA_THREAD"
 fi
 #
-# zdotc and adotu
+# zdotc and zdotu
 #
-AC_ARG_ENABLE(zdot, [AS_HELP_STRING([--disable-zdot],
-                           [Do not use ZDOTC and ZDOTU in BLAS.])],,
-                           [enable_zdot=yes])
-if test x"$enable_zdot" != xyes; then
-  FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+# The reference (f2c/g77) BLAS returns a COMPLEX result through a hidden first
+# pointer argument, whereas komega_math.F90 declares zdotc/zdotu as ordinary
+# register-return COMPLEX(8) FUNCTIONs. Calling such a BLAS through that
+# declaration crashes (observed on macOS/Accelerate). When --enable-zdot or
+# --disable-zdot is given explicitly we honor it; otherwise we autodetect the
+# BLAS complex-return ABI and fall back to Fortran intrinsics (-D__NO_ZDOT)
+# whenever the BLAS zdotc does not use the register-return convention.
+# zdotu shares the same complex-return convention as zdotc, so probing zdotc
+# alone is sufficient.
+#
+AC_ARG_ENABLE(zdot, [AS_HELP_STRING([--enable-zdot, --disable-zdot],
+                           [Use (yes) or do not use (no) ZDOTC and ZDOTU from
+                            BLAS. Default: autodetect the BLAS ABI.])],
+                           [zdot_explicit=yes],
+                           [zdot_explicit=no; enable_zdot=yes])
+if test x"$zdot_explicit" = xyes; then
+  if test x"$enable_zdot" != xyes; then
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  fi
+else
+  AC_LANG_PUSH([Fortran])
+  ac_save_LIBS="$LIBS"
+  LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS"
+  AC_MSG_CHECKING([whether BLAS zdotc uses the register-return ABI])
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+      program conftest_zdotc
+      implicit none
+      complex(8) :: zx(2), zy(2), res
+      complex(8) :: zdotc
+      external zdotc
+      zx(1) = (1d0, 0d0)
+      zx(2) = (0d0, 1d0)
+      zy(1) = (1d0, 0d0)
+      zy(2) = (0d0, 1d0)
+      res = zdotc(2, zx, 1, zy, 1)
+      if (abs(dble(res) - 2d0) < 1d-8 .and. abs(aimag(res)) < 1d-8) then
+        stop 0
+      else
+        stop 1
+      end if
+      end program conftest_zdotc
+]])],
+    [zdot_abi_ok=yes],
+    [zdot_abi_ok=no],
+    [zdot_abi_ok=cross])
+  LIBS="$ac_save_LIBS"
+  AC_LANG_POP([Fortran])
+  if test x"$zdot_abi_ok" = xyes; then
+    AC_MSG_RESULT([yes])
+  elif test x"$zdot_abi_ok" = xcross; then
+    AC_MSG_RESULT([assuming no (cross-compiling)])
+    AC_MSG_WARN([cannot run a test program while cross-compiling; assuming the
+                 BLAS zdotc/zdotu are unusable and defining -D__NO_ZDOT. Pass
+                 --enable-zdot to force use of the BLAS routines.])
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  else
+    AC_MSG_RESULT([no])
+    FCFLAGS="$FCFLAGS -D__NO_ZDOT"
+  fi
 fi
 echo ""
 echo "  Output files"


### PR DESCRIPTION
## Motivation

`src/komega_math.F90` declares `zdotc`/`zdotu` as ordinary register-return
`COMPLEX(8) FUNCTION`s. The reference (f2c/g77) BLAS — and Apple Accelerate on
macOS — instead returns a COMPLEX result through a *hidden first pointer
argument*. Calling such a BLAS through the register-return declaration crashes
(SIGSEGV). Until now the only remedy was for the user to know to pass
`--disable-zdot` by hand; a bare `./configure` on macOS/Accelerate produced
binaries that segfault in every complex-dot solver (BiCG, COCG, CG_C).

## Change

`configure` now decides the `__NO_ZDOT` switch automatically:

1. If `--enable-zdot` or `--disable-zdot` is given **explicitly**, honor it
   (no autodetection).
2. Otherwise **autodetect** the BLAS complex-return ABI: compile, link (with the
   same `FCFLAGS`/`LDFLAGS`/`LAPACK_LIBS`/`BLAS_LIBS`/`LIBS` the build uses) and
   run a tiny program that calls the register-return-declared `zdotc` on a known
   vector (`zdotc([1,i],[1,i]) = 2`).
   - Returns the correct value -> keep the optimized BLAS dot (no `__NO_ZDOT`).
   - Wrong value or crash -> define `-D__NO_ZDOT` so `komega_math.F90` uses the
     Fortran intrinsics `DOT_PRODUCT`/`SUM`.
3. When **cross-compiling** (probe cannot run) -> default to the safe path
   (`-D__NO_ZDOT`) with an `AC_MSG_WARN`.

`zdotu` shares `zdotc`'s convention, so probing `zdotc` alone suffices. No
solver/math code changes — only the build-time selection of the pre-existing
`__NO_ZDOT` path.

`configure.ac` carries the proper `AC_RUN_IFELSE`; the committed generated
`configure` is hand-edited equivalently (autotools were not available to
regenerate) and links the probe with
`$FCFLAGS $LDFLAGS ... $LAPACK_LIBS $BLAS_LIBS $LIBS` to mirror the autoconf
link line. The probe uses standard `stop 0` / `stop 1` (no compiler extensions).

## Validation (macOS arm64, gfortran + reference BLAS / Accelerate)

| invocation | autodetect | `-D__NO_ZDOT` | result |
|---|---|---|---|
| `./configure FC=gfortran` (bare) | runs -> no | yes | all 4 solvers converge, residual ~1e-13 |
| `./configure FC=mpif90` (bare) | runs -> no | yes | build clean, solvers converge |
| `LIBS=-lm ./configure` | runs -> no | yes | probe still links & detects |
| `./configure --enable-zdot` | skipped | no | BLAS path forced (complex solvers crash, as expected for explicit override) |
| `./configure --disable-zdot` | skipped | yes | all 4 solvers converge |
| `cross_compiling=yes` (forced) | fallback | yes | warns, defines `-D__NO_ZDOT` |

Before this change, a bare `./configure` left `solve_cc/cr/rc` segfaulting; after
it, all four `solve_*.x` drivers converge in 4-5 iterations.

> Note: the new configure-time branches are validated manually here but not yet
> wired into CI `make check`; a maintainer smoke test covering the four cases
> would be a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)