### PR TITLE
README: add CI, license, and documentation badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 <img src="doc/figs/komega.png" width="300">
 
+[![CI](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml/badge.svg)](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml)
+[![License: LGPL](https://img.shields.io/badge/License-LGPL-blue.svg)](COPYING.LESSER)
+[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://issp-center-dev.github.io/Komega/)
+
 # What ? 
 
 This package provides the solver library based on Shifted-Krylov subspace method and the software to calculate dynamical Green function by inputting the Hamiltonian and the vector of the excited state.

--- a/README_ja.md
+++ b/README_ja.md
@@ -3,6 +3,10 @@
 
 <img src="doc/figs/komega.png" width="300">
 
+[![CI](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml/badge.svg)](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml)
+[![License: LGPL](https://img.shields.io/badge/License-LGPL-blue.svg)](COPYING.LESSER)
+[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://issp-center-dev.github.io/Komega/)
+
 # What ? 
 
 Shifted-Krylov部分空間法に基づくソルバーライブラリと,


### PR DESCRIPTION
Adds a one-line badge block under the logo in `README.md` and `README_ja.md`
(kept identical between the two):

* **CI** — the GitHub Actions `ci.yml` workflow (added in #10):
  `[![CI](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml/badge.svg)](https://github.com/issp-center-dev/Komega/actions/workflows/ci.yml)`
* **License: LGPL** → `COPYING.LESSER`. The badge intentionally states no
  version: the source headers grant *"version 2.1 … or any later version"*
  while the bundled `COPYING.LESSER` text is LGPLv3, so an unversioned `LGPL`
  label is the accurate, non-misleading choice that matches the linked file.
* **Documentation** → the hosted GitHub Pages manual hub
  `https://issp-center-dev.github.io/Komega/`.

All three badge targets were verified to resolve (HTTP 200). This is a
docs-only change; no code or build impact.

> Follow-up to #10 (which introduced the CI workflow). #10 was already merged
> when these badges were prepared, so they go in a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)